### PR TITLE
feat: 최근 본 가게 조회/저장/업데이트 #63

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,30 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Reset } from 'styled-reset';
 
 import Routes from 'routes';
 
 import { Container } from 'components/common/styles';
 import useAuthState from 'hooks/useAuthState';
+import { useRecentStoresActions, useUserId } from 'store';
 
 function App() {
+  const userId = useUserId();
+
+  const { setRecentStore, setRecentStoreLoading } = useRecentStoresActions();
+  setRecentStoreLoading(true);
   useAuthState();
+
+  useEffect(() => {
+    // 로컬스토리지 값 가져오기
+    if (userId) {
+      const recentStores = localStorage.getItem('recentStores-' + userId);
+      console.log();
+      if (recentStores) {
+        setRecentStore(JSON.parse(recentStores));
+      }
+      setRecentStoreLoading(false);
+    }
+  }, [userId, setRecentStore, setRecentStoreLoading]);
 
   return (
     <div className="App">

--- a/src/components/MyPage/index.tsx
+++ b/src/components/MyPage/index.tsx
@@ -3,7 +3,7 @@ import PrevButton from 'components/common/PrevButton';
 import React from 'react';
 import UserInfo from './UserInfo';
 import { MyPageContainer } from './styles';
-import { useUserActions } from 'store';
+import { useUserActions, useUserId } from 'store';
 import { auth } from '../../firebase';
 import { signOut } from 'firebase/auth';
 import { useNavigate } from 'react-router-dom';
@@ -11,11 +11,13 @@ import { useNavigate } from 'react-router-dom';
 export default function MyPage() {
   const { setInitUser } = useUserActions();
   const navigate = useNavigate();
+  const userId = useUserId();
 
   const logOut = () => {
     if (window.confirm('로그아웃 하시겠습니까?')) {
       setInitUser();
       signOut(auth);
+      localStorage.removeItem('recentStores-' + userId);
       navigate('/login');
     }
   };

--- a/src/components/Search/RecentStores.tsx
+++ b/src/components/Search/RecentStores.tsx
@@ -1,57 +1,22 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { useRecentStores, useRecentStoresLoading } from 'store';
+import StoreListItem from './StoreListItem';
 
 export default function RecentStores() {
+  const recentStores = useRecentStores();
+  const isLoading = useRecentStoresLoading();
+
   return (
     <div>
-      {/* 세션스토리지에서 가져와서 뿌리기... */}
       <h2>최근 본 가게</h2>
       <ul>
-        <li>
-          <Link to="/store/detail/1">
-            <img src={require(`../../assets/images/stores/족발야시장로고.jpg`)} alt="곽만근갈비탕" />
-            <div className="info">
-              <p className="storeName">곽만근갈비탕</p>
-              <p className="category">한식</p>
-            </div>
-            <i
-              className="fa-solid fa-xmark"
-              onClick={(e) => {
-                e.preventDefault();
-              }}
-            ></i>
-          </Link>
-        </li>
-        <li>
-          <Link to="/store/detail/1">
-            <img src={require(`../../assets/images/stores/59쌀피자로고.jpg`)} alt="곽만근갈비탕" />
-            <div className="info">
-              <p className="storeName">59쌀피자</p>
-              <p className="category">패스트푸드</p>
-            </div>
-            <i
-              className="fa-solid fa-xmark"
-              onClick={(e) => {
-                e.preventDefault();
-              }}
-            ></i>
-          </Link>
-        </li>
-        <li>
-          <Link to="/store/detail/1">
-            <img src={require(`../../assets/images/stores/두끼로고.jpg`)} alt="곽만근갈비탕" />
-            <div className="info">
-              <p className="storeName">곽만근갈비탕</p>
-              <p className="category">한식</p>
-            </div>
-            <i
-              className="fa-solid fa-xmark"
-              onClick={(e) => {
-                e.preventDefault();
-              }}
-            ></i>
-          </Link>
-        </li>
+        {isLoading ? (
+          <p>불러오는 중...</p>
+        ) : recentStores.length ? (
+          recentStores.map((storeInfo) => <StoreListItem storeInfo={storeInfo} key={storeInfo.id} />)
+        ) : (
+          <p>최근 조회한 가게가 없습니다.</p>
+        )}
       </ul>
     </div>
   );

--- a/src/components/Search/StoreListItem.tsx
+++ b/src/components/Search/StoreListItem.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { useRecentStores, useRecentStoresActions, useUserId } from 'store';
 import { StoreInfo } from 'types/responseTypes';
 import { categoryName } from 'utils/common';
 
@@ -8,6 +9,21 @@ interface Props {
 }
 
 export default function StoreListItem({ storeInfo }: Props) {
+  const { setRecentStore } = useRecentStoresActions();
+  const recentStores = useRecentStores();
+  const userId = useUserId();
+
+  const clickDeleteBtn = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+    e.preventDefault();
+
+    const STORAGE_KEY = 'recentStores-' + userId;
+    const newRecentStore = [...recentStores];
+    const findIdx = newRecentStore.findIndex((store) => store.id === storeInfo.id);
+    newRecentStore.splice(findIdx, 1);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(newRecentStore));
+    setRecentStore(newRecentStore);
+  };
+
   return (
     <li>
       <Link to={`/store/detail/${storeInfo.id}`}>
@@ -16,6 +32,7 @@ export default function StoreListItem({ storeInfo }: Props) {
           <p className="storeName">{storeInfo.storeName}</p>
           <p className="category">{categoryName[storeInfo.category]}</p>
         </div>
+        <i className="fa-solid fa-xmark" onClick={clickDeleteBtn}></i>
       </Link>
     </li>
   );

--- a/src/components/Search/styles.tsx
+++ b/src/components/Search/styles.tsx
@@ -67,7 +67,8 @@ export const SearchContentsContainer = styled.div`
 
   ul {
     li {
-      margin-bottom: 2.5%;
+      border-bottom: 1px solid #ddd;
+      padding: 2.5%;
 
       a {
         display: flex;
@@ -97,7 +98,7 @@ export const SearchContentsContainer = styled.div`
           align-self: center;
           font-size: 25px;
           &:hover {
-            color: #e08e00;
+            color: #ff8c00;
           }
         }
       }

--- a/src/components/StoreDetail/hooks/useRecentStoreNLocalStorage.ts
+++ b/src/components/StoreDetail/hooks/useRecentStoreNLocalStorage.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { useRecentStores, useRecentStoresActions } from 'store';
+import { StoreInfo } from 'types/responseTypes';
+
+const STORAGE_KEY_PREFIX = 'recentStores-';
+
+function useRecentStoreNLocalStorage(storeDetailInfo: StoreInfo | undefined, userId: string) {
+  const recentStores = useRecentStores();
+  const { setRecentStore } = useRecentStoresActions();
+
+  useEffect(() => {
+    if (storeDetailInfo) {
+      const STORAGE_KEY = STORAGE_KEY_PREFIX + userId;
+      const findIndex = recentStores.findIndex((store) => store.id === storeDetailInfo.id);
+      let newRecentStores;
+
+      if (findIndex === -1) {
+        newRecentStores = [storeDetailInfo, ...recentStores];
+      } else if (findIndex > 0) {
+        newRecentStores = [...recentStores];
+        const [store] = newRecentStores.splice(findIndex, 1);
+        newRecentStores.unshift(store);
+      }
+
+      if (newRecentStores) {
+        setRecentStore(newRecentStores);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(newRecentStores));
+      }
+    }
+  }, [storeDetailInfo, recentStores, setRecentStore, userId]);
+}
+
+export default useRecentStoreNLocalStorage;

--- a/src/components/StoreDetail/index.tsx
+++ b/src/components/StoreDetail/index.tsx
@@ -8,6 +8,8 @@ import PrevButton from 'components/common/PrevButton';
 import { useParams } from 'react-router-dom';
 import useStoreDetailQuery from './hooks/useStoreDetailQuery';
 import { Message } from 'components/common/styles';
+import { useUserId } from 'store';
+import useRecentStoreNLocalStorage from './hooks/useRecentStoreNLocalStorage';
 
 export default function StoreDetail() {
   const { storeId } = useParams();
@@ -16,7 +18,11 @@ export default function StoreDetail() {
     throw new Error('매장 id 추출 중 오류발생.');
   }
 
+  const userId = useUserId();
   const { isLoading, data: storeDetailInfo, isError, error } = useStoreDetailQuery(storeId);
+
+  // 로컬스토리지에 넣기
+  useRecentStoreNLocalStorage(storeDetailInfo, userId);
 
   return (
     <>

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,4 @@
-import { IOrderStore, IUserStore } from 'types/storeTypes';
+import { IOrderStore, IRecentStores, IUserStore } from 'types/storeTypes';
 import { auth } from './firebase';
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
@@ -118,3 +118,25 @@ export const useOrderInfo = () =>
   }));
 
 export const useOrderListAction = () => useOrderStore((state) => state.actions);
+
+// 로컬스토리지의 최근 조회 가게
+const useRecentStoresStore = create<IRecentStores>()(
+  devtools(
+    immer((set) => ({
+      loading: false,
+      recentStores: [],
+      actions: {
+        setRecentStoreLoading: (bool) => {
+          set({ loading: bool });
+        },
+        setRecentStore: (stores) => {
+          set({ recentStores: stores });
+        },
+      },
+    })),
+  ),
+);
+
+export const useRecentStoresLoading = () => useRecentStoresStore((state) => state.loading);
+export const useRecentStores = () => useRecentStoresStore((state) => state.recentStores);
+export const useRecentStoresActions = () => useRecentStoresStore((state) => state.actions);

--- a/src/types/storeTypes.ts
+++ b/src/types/storeTypes.ts
@@ -1,4 +1,4 @@
-import { IOrderItem, IUserOrderListItemRes } from './responseTypes';
+import { IOrderItem, IUserOrderListItemRes, StoreInfo } from './responseTypes';
 
 export interface IUserStore {
   loading: boolean;
@@ -30,5 +30,14 @@ export interface IOrderStore {
     deleteMenu: (idx: number) => void;
     increaseMenuCount: (idx: number) => void;
     decreaseMenuCount: (idx: number) => void;
+  };
+}
+
+export interface IRecentStores {
+  loading: boolean;
+  recentStores: StoreInfo[];
+  actions: {
+    setRecentStoreLoading: (bool: boolean) => void;
+    setRecentStore: (stores: StoreInfo[]) => void;
   };
 }


### PR DESCRIPTION
- 최근 본 가게정보 전역상태 관리 및 로컬스토리지 동기화
- 로컬스토리지 기반 최근 본 가게 렌더
- 가게 조회 시 로컬스토리지에 최근 조회한 가게 리스트 업데이트
- 삭제 버튼 클릭 시 로컬스토리지 내 해당 리스트 삭제 및 리렌더